### PR TITLE
Permite que, no update do usuário, o campo código seja passado como nulo

### DIFF
--- a/app/Controllers/Http/UsuariosController.ts
+++ b/app/Controllers/Http/UsuariosController.ts
@@ -85,6 +85,7 @@ export default class UsuariosController {
     const validateData = await request.validate(UsuarioValidatorUpdate)
 
     const usuario = await Usuario.findOrFail(id)
+    
     usuario.merge(limpaCamposNulosDeObjeto(validateData))
     await usuario.save()
     return usuario

--- a/app/Utils/Utils.ts
+++ b/app/Utils/Utils.ts
@@ -1,10 +1,13 @@
 export function limpaCamposNulosDeObjeto(objetoSujo: Object):Object {
+    console.log(objetoSujo);
     const chaves = Object.keys(objetoSujo)
     let objetoLimpo = {}
     chaves.forEach((chave) => {
-      if (objetoSujo[chave] !== undefined && objetoSujo[chave] !== null ) {
+      if (objetoSujo[chave] !== undefined ) {
         objetoLimpo[chave] = objetoSujo[chave]
       }
     })
+
+
     return objetoLimpo
 }

--- a/app/Validators/UsuarioValidator.ts
+++ b/app/Validators/UsuarioValidator.ts
@@ -49,7 +49,7 @@ export class UsuarioValidatorUpdate {
     tipo: schema.enum.optional(['MASTER', 'SECRETARIA(O)', 'PACIENTE']),
     aprovado: schema.boolean.optional(),
     avatar_url: schema.string.optional({ trim: true }),
-    codigo: schema.string.optional({ trim: true }),
+    codigo: schema.string.nullableAndOptional({ trim: true }),
   })
 
   public messages = {


### PR DESCRIPTION
Tal permissão se dá pela propriedade nullableAndOptional no validator do usuário. Além disso, a função limpaCamposNulosObjeto foi alterada, de forma que os campos nulos não são limpos, apenas os undefined.